### PR TITLE
use testuser for the runtime tests

### DIFF
--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -5,31 +5,31 @@ As a user
 I want to perform operations on process instances
 
 Scenario: cancel a process instance
-Given the user is authenticated as an hruser
+Given the user is authenticated as a testuser
 When the user starts a process with variables
 And cancel the process
 Then the process instance is cancelled
 
 Scenario: try activate a cancelled process instance
-Given any authenticated user
+Given the user is authenticated as a testuser
 And any suspended process instance
 When the user cancel the process
 Then the process cannot be activated anymore
 
 Scenario: show a process instance diagram
-Given the user is authenticated as an hruser
+Given the user is authenticated as a testuser
 When the user starts a process with variables
 And open the process diagram
 Then the diagram is shown
 
 Scenario: show diagram for a process instance without graphic info
-Given the user is authenticated as an hruser
+Given the user is authenticated as a testuser
 When the user starts a process without graphic info
 And open the process diagram
 Then no diagram is shown
 
 Scenario: complete a process instance that uses a connector
-Given the user is authenticated as an hruser
+Given the user is authenticated as a testuser
 When the user starts a connector process
 Then the status of the process is changed to completed
 And a variable was created with name var1

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
@@ -6,7 +6,7 @@ I want to perform an operation on tasks
 So that I can get results on a running process
 
 Scenario: claim and complete tasks in a running process
-Given the user is authenticated as an hruser
+Given the user is authenticated as a testuser
 When the user starts a process with variables
 And the user claims a task
 And the user completes the task

--- a/security-policies-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/SecurityPoliciesActions.java
+++ b/security-policies-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/SecurityPoliciesActions.java
@@ -51,7 +51,7 @@ public class SecurityPoliciesActions {
         try {
             runtimeBundleSteps.startProcess(PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY);
         }catch (FeignException exception){
-            assertThat(exception.getMessage()).contains("Operation not permitted for ProcessWithVariables");
+            assertThat(exception.getMessage()).contains("Unable to find process definition for the given");
         }
     }
 


### PR DESCRIPTION
use testuser for the runtime tests so that they work with the policies applied for security tests