### PR TITLE
modeling backend path now distinguished from frontend

### DIFF
--- a/modeling-acceptance-tests/src/main/resources/config-env.properties
+++ b/modeling-acceptance-tests/src/main/resources/config-env.properties
@@ -1,3 +1,4 @@
 realm=springboot
 auth.url=http://${SSO_HOST}/auth/realms/${realm}/protocol/openid-connect/token
-modeling.url=http://${GATEWAY_HOST}/activiti-cloud-modeling
+modeling.path=activiti-cloud-modeling-backend
+modeling.url=http://${GATEWAY_HOST}/${modeling.path}

--- a/modeling-acceptance-tests/src/main/resources/config-kubernetes.properties
+++ b/modeling-acceptance-tests/src/main/resources/config-kubernetes.properties
@@ -1,3 +1,4 @@
 realm=springboot
 auth.url=http://activiti-cloud-sso-idm-kub:30081/auth/realms/${realm}/protocol/openid-connect/token
-modeling.url=http://activiti-cloud-sso-idm-kub:30080/activiti-cloud-modeling
+modeling.path=activiti-cloud-modeling-backend
+modeling.url=http://activiti-cloud-sso-idm-kub:30080/${modeling.path}


### PR DESCRIPTION
This is needed because the [backend is now on a different path](https://github.com/Activiti/activiti-cloud-charts/blob/master/activiti-cloud-modeling/values.yaml#L97) from [the frontend path](https://github.com/Activiti/activiti-cloud-charts/blob/master/activiti-cloud-modeling/values.yaml#L112) and has also changed from what it used to be. Also parameterising so that it can be overridden (e.g. for running against a local env). We can alternatively change the chart but then we need a different name for accessing the frontend in the cluster.