### PR TITLE
Start Process With Process Instance Name via rest and Java APIs #1952

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/QuerySteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/QuerySteps.java
@@ -166,4 +166,11 @@ public class QuerySteps {
 
 
 
+    @Step
+    public void checkProcessInstanceName(String processInstanceId,
+                                         String processInstanceName) {
+        await().untilAsserted(() -> assertThat(queryService.getProcessInstance(processInstanceId).getName())
+                .isNotNull()
+                .isEqualTo(processInstanceName));
+    }
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
@@ -94,6 +94,16 @@ public class RuntimeBundleSteps {
     }
 
     @Step
+    public CloudProcessInstance startProcessWithProcessInstanceName(String process,
+                                                                    String processName) {
+        return dirtyContextHandler.dirty(runtimeBundleService.startProcess(ProcessPayloadBuilder
+                                                                                   .start()
+                                                                                   .withProcessInstanceName(processName)
+                                                                                   .withProcessDefinitionKey(process)
+                                                                                   .build()));
+    }
+
+    @Step
     public Collection<CloudTask> getTaskByProcessInstanceId(String processInstanceId) {
         return runtimeBundleService
                 .getProcessInstanceTasks(processInstanceId).getContent();
@@ -261,6 +271,12 @@ public class RuntimeBundleSteps {
         }catch (FeignException exception) {
             assertThat(exception.getMessage()).contains("Unable to find process instance for the given id:'" + id+ "'");
         }
+    }
+
+    @Step
+    public void checkProcessInstanceName(String processInstanceId,
+                                         String processInstanceName) {
+        assertThat(runtimeBundleService.getProcessInstance(processInstanceId).getName()).isEqualTo(processInstanceName);
     }
 
     @Step

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -295,4 +295,19 @@ public class ProcessInstanceTasks {
                 .extracting(field)
                 .contains(value);
     }
+
+    @When("the user set a process instance name $myProcessInstanceName and starts the process $processName")
+    public void startProcessWithProcessInstanceName(String myProcessInstanceName,
+                                                    String processName) {
+        processInstance = runtimeBundleSteps.startProcessWithProcessInstanceName(processDefinitionKeyMatcher(processName),
+                                                                                 myProcessInstanceName);
+    }
+
+    @Then("verify the process instance name is $myProcessInstanceName")
+    public void verifyTheProcessInstanceNameIsTheOneSupplied(String myProcessInstanceName) {
+        runtimeBundleSteps.checkProcessInstanceName(processInstance.getId(),
+                                                    myProcessInstanceName);
+        querySteps.checkProcessInstanceName(processInstance.getId(),
+                                            myProcessInstanceName);
+    }
 }

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -58,3 +58,8 @@ Scenario: check the presence of formKey field in task
 Given the user is authenticated as testuser
 Then the PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED definition has the formKey field with value startForm
 
+
+Scenario: start a process instance with a name
+Given the user is authenticated as testuser
+When the user set a process instance name my_process_instance_name and starts the process SIMPLE_PROCESS_INSTANCE
+Then verify the process instance name is my_process_instance_name


### PR DESCRIPTION
- created a scenario to validate start a process with process instance name which is also present in query service

refs [#1952](https://github.com/Activiti/Activiti/issues/1952)