### PR TITLE
Add Process Matcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <activiti-cloud.version>7.0.71</activiti-cloud.version>
+    <activiti-cloud.version>7.0.75</activiti-cloud.version>
     <activiti-cloud-modeling.version>7.0.3</activiti-cloud-modeling.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <enforcer.skip>true</enforcer.skip>

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/Filters.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/Filters.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.cloud.qa.helper;
 
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessDefinitionRegistry.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessDefinitionRegistry.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.qa.helper;
 
 import java.util.HashMap;
 
-public class ProcessMatcher {
+public class ProcessDefinitionRegistry {
 
     private static final HashMap <String, String> processWithTasksDefinitionKeys = new HashMap<String, String>(){{
             put("PROCESS_INSTANCE_WITH_VARIABLES","ProcessWithVariables");

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessMatcher.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessMatcher.java
@@ -22,16 +22,18 @@ public class ProcessMatcher {
 
     private static final HashMap <String, String> processWithTasksDefinitionKeys = new HashMap<String, String>(){{
             put("PROCESS_INSTANCE_WITH_VARIABLES","ProcessWithVariables");
-            put("PROCESS_INSTANCE_WITH_SINGLE_TASK","SingleTaskProcess");
+            put("PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED","SingleTaskProcess");
             put("PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES","SingleTaskProcessUserCandidates");
             put("PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES","SingleTaskProcessGroupCandidates");
             put("PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO","fixSystemFailure");
             put("PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP","singletask-b6095889-6177-4b73-b3d9-316e47749a36");
+            put("SUB_PROCESS_INSTANCE_WITH_TASK","subprocess-970cb8df-2d4c-482b-a7f8-c19a983c2ef2");
     }};
 
     private static final HashMap <String, String> processWithNoTasksDefinitionKeys = new HashMap<String, String>(){{
             put("SIMPLE_PROCESS_INSTANCE","SimpleProcess");
             put("CONNECTOR_PROCESS_INSTANCE","ConnectorProcess");
+            put("PROCESS_INSTANCE_WITH_CALL_ACTIVITIES","parentproc-8e992556-5785-4ee0-9fe7-354decfea4a8");
     }};
 
     public static final HashMap <String, String> processDefinitionKeys = new HashMap<String, String>(){{
@@ -47,3 +49,8 @@ public class ProcessMatcher {
         return processWithTasksDefinitionKeys.containsKey(processName);
     }
 }
+
+
+
+
+

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessMatcher.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessMatcher.java
@@ -20,25 +20,6 @@ import java.util.HashMap;
 
 public class ProcessMatcher {
 
-//    public enum ProcessDefinitionKey {
-//
-//        SIMPLE_PROCESS_INSTANCE ("SimpleProcess"),
-//        CONNECTOR_PROCESS_INSTANCE("ConnectorProcess"),
-//        PROCESS_INSTANCE_WITH_VARIABLES("ProcessWithVariables"),
-//        PROCESS_INSTANCE_WITH_SINGLE_TASK("SingleTaskProcess"),
-//        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES("SingleTaskProcessUserCandidates"),
-//        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES("SingleTaskProcessGroupCandidates"),
-//        PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO("fixSystemFailure"),
-//        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP("singletask-b6095889-6177-4b73-b3d9-316e47749a36");
-//
-//        private String processDefinitionKey;
-//        ProcessDefinitionKey(String processDefinitionKey){
-//            this.processDefinitionKey = processDefinitionKey;
-//        }
-//        public String getProcessDefinitionKey(){
-//            return this.processDefinitionKey;
-//        }
-//    }
     private static final HashMap <String, String> processWithTasksDefinitionKeys = new HashMap<String, String>(){{
             put("PROCESS_INSTANCE_WITH_VARIABLES","ProcessWithVariables");
             put("PROCESS_INSTANCE_WITH_SINGLE_TASK","SingleTaskProcess");
@@ -62,52 +43,7 @@ public class ProcessMatcher {
         return processDefinitionKeys.get(processName);
     }
 
-//    processDefinitionKeys.get("SIMPLE_PROCESS_INSTANCE")
-//
-//            processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES")
-
-
-//    public static String processDefinitionKeyMatcher (String processName){
-//
-//        String processDefinitionKey;
-//
-//        switch(processName) {
-//            case "process with variables":
-//                processDefinitionKey = processDefinitionKeys.get(processName);
-//                break;
-//            case "single-task process":
-//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITH_SINGLE_TASK.getProcessDefinitionKey();
-//                break;
-//            case "single-task process with user candidates":
-//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES.getProcessDefinitionKey();
-//                break;
-//            case "single-task process with group candidates":
-//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES.getProcessDefinitionKey();
-//                break;
-//            case "process without graphic info":
-//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO.getProcessDefinitionKey();
-//                break;
-//            case "connector process":
-//                processDefinitionKey = ProcessDefinitionKey.CONNECTOR_PROCESS_INSTANCE.getProcessDefinitionKey();
-//                break;
-//            case "single-task process with group candidates for test group":
-//                processDefinitionKey =  ProcessDefinitionKey.
-//                                        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP
-//                                        .getProcessDefinitionKey();
-//                break;
-//            default:
-//                processDefinitionKey = ProcessDefinitionKey.SIMPLE_PROCESS_INSTANCE.getProcessDefinitionKey();
-//        }
-//
-//        return processDefinitionKey;
-//    }
-
     public static boolean withTasks(String processName) {
-//        if(processName.equals("connector process") || processName.equals("any"))
-//            return false;
-//        else
-//            return true;
-
         return processWithTasksDefinitionKeys.containsKey(processName);
     }
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessMatcher.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helper/ProcessMatcher.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.qa.helper;
+
+import java.util.HashMap;
+
+public class ProcessMatcher {
+
+//    public enum ProcessDefinitionKey {
+//
+//        SIMPLE_PROCESS_INSTANCE ("SimpleProcess"),
+//        CONNECTOR_PROCESS_INSTANCE("ConnectorProcess"),
+//        PROCESS_INSTANCE_WITH_VARIABLES("ProcessWithVariables"),
+//        PROCESS_INSTANCE_WITH_SINGLE_TASK("SingleTaskProcess"),
+//        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES("SingleTaskProcessUserCandidates"),
+//        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES("SingleTaskProcessGroupCandidates"),
+//        PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO("fixSystemFailure"),
+//        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP("singletask-b6095889-6177-4b73-b3d9-316e47749a36");
+//
+//        private String processDefinitionKey;
+//        ProcessDefinitionKey(String processDefinitionKey){
+//            this.processDefinitionKey = processDefinitionKey;
+//        }
+//        public String getProcessDefinitionKey(){
+//            return this.processDefinitionKey;
+//        }
+//    }
+    private static final HashMap <String, String> processWithTasksDefinitionKeys = new HashMap<String, String>(){{
+            put("PROCESS_INSTANCE_WITH_VARIABLES","ProcessWithVariables");
+            put("PROCESS_INSTANCE_WITH_SINGLE_TASK","SingleTaskProcess");
+            put("PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES","SingleTaskProcessUserCandidates");
+            put("PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES","SingleTaskProcessGroupCandidates");
+            put("PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO","fixSystemFailure");
+            put("PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP","singletask-b6095889-6177-4b73-b3d9-316e47749a36");
+    }};
+
+    private static final HashMap <String, String> processWithNoTasksDefinitionKeys = new HashMap<String, String>(){{
+            put("SIMPLE_PROCESS_INSTANCE","SimpleProcess");
+            put("CONNECTOR_PROCESS_INSTANCE","ConnectorProcess");
+    }};
+
+    public static final HashMap <String, String> processDefinitionKeys = new HashMap<String, String>(){{
+            putAll(processWithTasksDefinitionKeys);
+            putAll(processWithNoTasksDefinitionKeys);
+    }};
+
+    public static String processDefinitionKeyMatcher (String processName){
+        return processDefinitionKeys.get(processName);
+    }
+
+//    processDefinitionKeys.get("SIMPLE_PROCESS_INSTANCE")
+//
+//            processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES")
+
+
+//    public static String processDefinitionKeyMatcher (String processName){
+//
+//        String processDefinitionKey;
+//
+//        switch(processName) {
+//            case "process with variables":
+//                processDefinitionKey = processDefinitionKeys.get(processName);
+//                break;
+//            case "single-task process":
+//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITH_SINGLE_TASK.getProcessDefinitionKey();
+//                break;
+//            case "single-task process with user candidates":
+//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES.getProcessDefinitionKey();
+//                break;
+//            case "single-task process with group candidates":
+//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES.getProcessDefinitionKey();
+//                break;
+//            case "process without graphic info":
+//                processDefinitionKey = ProcessDefinitionKey.PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO.getProcessDefinitionKey();
+//                break;
+//            case "connector process":
+//                processDefinitionKey = ProcessDefinitionKey.CONNECTOR_PROCESS_INSTANCE.getProcessDefinitionKey();
+//                break;
+//            case "single-task process with group candidates for test group":
+//                processDefinitionKey =  ProcessDefinitionKey.
+//                                        PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP
+//                                        .getProcessDefinitionKey();
+//                break;
+//            default:
+//                processDefinitionKey = ProcessDefinitionKey.SIMPLE_PROCESS_INSTANCE.getProcessDefinitionKey();
+//        }
+//
+//        return processDefinitionKey;
+//    }
+
+    public static boolean withTasks(String processName) {
+//        if(processName.equals("connector process") || processName.equals("any"))
+//            return false;
+//        else
+//            return true;
+
+        return processWithTasksDefinitionKeys.containsKey(processName);
+    }
+}

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/service/RuntimeBundleService.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/service/RuntimeBundleService.java
@@ -67,7 +67,7 @@ public interface RuntimeBundleService extends BaseService {
     @Headers("Content-Type: application/json")
     void deleteProcess(@Param("id") String id);
 
-    @RequestLine("GET /v1/process-instances")
+    @RequestLine("GET /v1/process-instances?sort=startDate,desc&sort=id,desc")
     @Headers("Content-Type: application/json")
     PagedResources<CloudProcessInstance> getAllProcessInstances();
 

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/service/RuntimeBundleService.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/service/RuntimeBundleService.java
@@ -111,4 +111,8 @@ public interface RuntimeBundleService extends BaseService {
     @RequestLine("GET /v1/process-definitions")
     @Headers("Content-Type: application/json")
     PagedResources<ProcessDefinition> getProcessDefinitions();
+
+    @RequestLine("GET /v1/process-definitions/{processDefinitionKey}")
+    @Headers("Content-Type: application/json")
+    ProcessDefinition getProcessDefinitionByKey(@Param("processDefinitionKey") String processDefinitionKey);
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/service/RuntimeBundleService.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/service/RuntimeBundleService.java
@@ -19,6 +19,7 @@ package org.activiti.cloud.qa.service;
 import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
+import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.task.model.payloads.CreateTaskPayload;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -106,4 +107,8 @@ public interface RuntimeBundleService extends BaseService {
             "Accept: application/hal+json;charset=UTF-8"
     })
     PagedResources<CloudTask> getAllTasks();
+
+    @RequestLine("GET /v1/process-definitions")
+    @Headers("Content-Type: application/json")
+    PagedResources<ProcessDefinition> getProcessDefinitions();
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/QuerySteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/QuerySteps.java
@@ -136,5 +136,12 @@ public class QuerySteps {
         return queryService.queryAllTasks();
     }
 
+    @Step
+    public CloudTask getTaskById(String id){
+        return queryService.queryTasksById(id).getContent().iterator().next();
+    }
+
+
+
 
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import feign.FeignException;
 import net.thucydides.core.annotations.Step;
-import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
@@ -51,20 +50,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  */
 @EnableRuntimeFeignContext
 public class RuntimeBundleSteps {
-
-    public static final String SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY = "SimpleProcess";
-
-    public static final String CONNECTOR_PROCESS_INSTANCE_DEFINITION_KEY = "ConnectorProcess";
-
-    public static final String PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY = "ProcessWithVariables";
-
-    public static final String PROCESS_INSTANCE_WITH_SINGLE_TASK_DEFINITION_KEY = "SingleTaskProcess";
-
-    public static final String PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES_DEFINITION_KEY = "SingleTaskProcessUserCandidates";
-
-    public static final String PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_DEFINITION_KEY = "SingleTaskProcessGroupCandidates";
-
-    public static final String PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO_DEFINITION_KEY = "fixSystemFailure";
 
     @Autowired
     private RuntimeDirtyContextHandler dirtyContextHandler;

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import feign.FeignException;
 import net.thucydides.core.annotations.Step;
+import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
@@ -252,6 +253,11 @@ public class RuntimeBundleSteps {
     @Step
     public void getProcessInstanceById(String id){
         runtimeBundleService.getProcessInstance(id);
+    }
+
+    @Step
+    public PagedResources<ProcessDefinition> getProcessDefinitions(){
+        return runtimeBundleService.getProcessDefinitions();
     }
 
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
+import com.sun.org.apache.xalan.internal.xslt.Process;
 import feign.FeignException;
 import net.thucydides.core.annotations.Step;
 import org.activiti.api.process.model.ProcessDefinition;
@@ -258,6 +259,11 @@ public class RuntimeBundleSteps {
     @Step
     public PagedResources<ProcessDefinition> getProcessDefinitions(){
         return runtimeBundleService.getProcessDefinitions();
+    }
+
+    @Step
+    public ProcessDefinition getProcessDefinitionByKey(String key){
+        return runtimeBundleService.getProcessDefinitionByKey(key);
     }
 
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/steps/RuntimeBundleSteps.java
@@ -249,4 +249,9 @@ public class RuntimeBundleSteps {
         }
     }
 
+    @Step
+    public void getProcessInstanceById(String id){
+        runtimeBundleService.getProcessInstance(id);
+    }
+
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -267,6 +267,17 @@ public class ProcessInstanceTasks {
     @Then("all the process definitions are present")
     public void checkProcessDefinitions(){
         Collection<ProcessDefinition> processDefinitions = Serenity.sessionVariableCalled("processDefinitions");
-        assertThat(processDefinitions).extracting("key").containsAll(processDefinitionKeys.values());
+        assertThat(processDefinitions)
+                .extracting("key")
+                .containsAll(processDefinitionKeys.values());
+    }
+
+    @Then("the $processName definition has the $field field with value $value")
+    public void checkIfFieldIsPresentAndHasValue(String processName, String field, String value){
+        ProcessDefinition processDefinition =   runtimeBundleSteps
+                                                .getProcessDefinitionByKey(processDefinitionKeyMatcher(processName));
+        assertThat(processDefinition)
+                .extracting(field)
+                .contains(value);
     }
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.qa.story;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
@@ -28,6 +29,7 @@ import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.qa.rest.error.ExpectRestNotFound;
 import org.activiti.cloud.qa.steps.AuditSteps;
 import org.activiti.cloud.qa.steps.QuerySteps;
@@ -237,5 +239,20 @@ public class ProcessInstanceTasks {
     @Then("the user can get process with variables instances in admin endpoint")
     public void checkIfProcessWithVariablesArePresentAdmin(){
         assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstancesAdmin(), processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isNotEmpty();
+    }
+
+    @Then("the task from $processName is $status and it is called $taskName")
+    public void checkTaskFromProcessInstance(String processName,Task.TaskStatus status, String taskName){
+        List<ProcessInstance> processInstancesList = new ArrayList<>(
+                runtimeBundleSteps.getAllProcessInstances().getContent());
+        assertThat(processInstancesList).hasSize(2);
+        assertThat(processInstancesList).extracting("processDefinitionKey")
+                                        .contains(processDefinitionKeyMatcher(processName));
+
+        List<Task> tasksList = new ArrayList<>(runtimeBundleSteps.getAllTasks().getContent());
+        assertThat(tasksList).isNotEmpty();
+        currentTask = tasksList.get(0);
+        assertThat(currentTask.getStatus()).isEqualTo(status);
+        assertThat(currentTask.getName()).isEqualTo(taskName);
     }
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -18,7 +18,6 @@ package org.activiti.cloud.qa.story;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
@@ -30,8 +29,6 @@ import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
-import org.activiti.cloud.api.task.model.CloudTask;
-import org.activiti.cloud.qa.helper.ProcessMatcher;
 import org.activiti.cloud.qa.rest.error.ExpectRestNotFound;
 import org.activiti.cloud.qa.steps.AuditSteps;
 import org.activiti.cloud.qa.steps.QuerySteps;
@@ -40,7 +37,7 @@ import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
 
-import static org.activiti.cloud.qa.helper.ProcessMatcher.*;
+import static org.activiti.cloud.qa.helper.ProcessDefinitionRegistry.*;
 import static org.activiti.cloud.qa.helper.Filters.checkEvents;
 import static org.activiti.cloud.qa.helper.Filters.checkProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -23,6 +23,7 @@ import java.util.List;
 import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
 import org.activiti.api.model.shared.event.VariableEvent;
+import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
@@ -30,6 +31,7 @@ import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.task.model.CloudTask;
+import org.activiti.cloud.qa.helper.ProcessMatcher;
 import org.activiti.cloud.qa.rest.error.ExpectRestNotFound;
 import org.activiti.cloud.qa.steps.AuditSteps;
 import org.activiti.cloud.qa.steps.QuerySteps;
@@ -254,5 +256,17 @@ public class ProcessInstanceTasks {
         currentTask = tasksList.get(0);
         assertThat(currentTask.getStatus()).isEqualTo(status);
         assertThat(currentTask.getName()).isEqualTo(taskName);
+    }
+
+    @When("the user gets the process definitions")
+    public void getProcessDefinitions(){
+        Collection<ProcessDefinition> processDefinitions = runtimeBundleSteps.getProcessDefinitions().getContent();
+        Serenity.setSessionVariable("processDefinitions").to(processDefinitions);
+    }
+
+    @Then("all the process definitions are present")
+    public void checkProcessDefinitions(){
+        Collection<ProcessDefinition> processDefinitions = Serenity.sessionVariableCalled("processDefinitions");
+        assertThat(processDefinitions).extracting("key").containsAll(processDefinitionKeys.values());
     }
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -19,7 +19,6 @@ package org.activiti.cloud.qa.story;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
 import org.activiti.api.model.shared.event.VariableEvent;
@@ -33,20 +32,13 @@ import org.activiti.cloud.qa.rest.error.ExpectRestNotFound;
 import org.activiti.cloud.qa.steps.AuditSteps;
 import org.activiti.cloud.qa.steps.QuerySteps;
 import org.activiti.cloud.qa.steps.RuntimeBundleSteps;
-import org.jbehave.core.annotations.Alias;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
 
+import static org.activiti.cloud.qa.helper.ProcessMatcher.*;
 import static org.activiti.cloud.qa.helper.Filters.checkEvents;
 import static org.activiti.cloud.qa.helper.Filters.checkProcessInstances;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.CONNECTOR_PROCESS_INSTANCE_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.PROCESS_INSTANCE_WITH_SINGLE_TASK_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO_DEFINITION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessInstanceTasks {
@@ -76,41 +68,10 @@ public class ProcessInstanceTasks {
     @When("the user starts a $processName")
     public void startProcess(String processName) {
 
-        String processDefinitionKey;
-        boolean withTasks = true;
-
-        switch(processName){
-            case "process with variables":
-                processDefinitionKey = PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY;
-                break;
-            case "single-task process":
-                processDefinitionKey = PROCESS_INSTANCE_WITH_SINGLE_TASK_DEFINITION_KEY;
-                break;
-            case "single-task process with user candidates":
-                processDefinitionKey = PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES_DEFINITION_KEY;
-                break;
-            case "single-task process with group candidates":
-                processDefinitionKey = PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_DEFINITION_KEY;
-                break;
-            case "process without graphic info":
-                processDefinitionKey = PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO_DEFINITION_KEY;
-                break;
-            case "connector process":
-                processDefinitionKey = CONNECTOR_PROCESS_INSTANCE_DEFINITION_KEY;
-                withTasks = false;
-                break;
-            case "single-task process with group candidates for test group":
-                processDefinitionKey = "singletask-b6095889-6177-4b73-b3d9-316e47749a36";
-                break;
-            default:
-                processDefinitionKey = SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY;
-                withTasks = false;
-        }
-
-        processInstance = runtimeBundleSteps.startProcess(processDefinitionKey);
+        processInstance = runtimeBundleSteps.startProcess(processDefinitionKeyMatcher(processName));
         assertThat(processInstance).isNotNull();
 
-        if(withTasks){
+        if(withTasks(processName)){
             List<Task> tasks = new ArrayList<>(
                     runtimeBundleSteps.getTaskByProcessInstanceId(processInstance.getId()));
             assertThat(tasks).isNotEmpty();
@@ -123,7 +84,7 @@ public class ProcessInstanceTasks {
 
     @Given("any suspended process instance")
     public void suspendCurrentProcessInstance() {
-        this.startProcess("any");
+        this.startProcess("SIMPLE_PROCESS_INSTANCE");
         runtimeBundleSteps.suspendProcessInstance(processInstance.getId());
     }
 
@@ -183,10 +144,10 @@ public class ProcessInstanceTasks {
         assertThat(tasks).extracting("id").doesNotContain(currentTask.getId());
     }
 
-    @Then("tasks of $definitionKey cannot be seen by user")
-    public void cannotSeeTasksOfDefinition(String defintionKey) throws Exception {
+    @Then("tasks of $processName cannot be seen by user")
+    public void cannotSeeTasksOfDefinition(String processName) throws Exception {
         Collection <? extends Task> tasks = querySteps.getAllTasks().getContent();
-        assertThat(tasks).extracting("processDefinitionId").doesNotContain(defintionKey);
+        assertThat(tasks).extracting("processDefinitionId").doesNotContain(processDefinitionKeyMatcher(processName));
     }
 
     @Then("the status of the process and the task is changed to completed")
@@ -263,18 +224,18 @@ public class ProcessInstanceTasks {
     @Then("the user can get events for process with variables instances in admin endpoint")
     public void checkIfEventsFromProcessesWithVariablesArePresentAdmin(){
         //TODO some refactoring after fixing the behavior of the /admin/v1/events?search=entityId:UUID endpoint
-        Collection<CloudRuntimeEvent> filteredCollection = checkEvents(auditSteps.getEventsByEntityIdAdmin(Serenity.sessionVariableCalled("processInstanceId")), PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY);
+        Collection<CloudRuntimeEvent> filteredCollection = checkEvents(auditSteps.getEventsByEntityIdAdmin(Serenity.sessionVariableCalled("processInstanceId")), processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"));
         assertThat(filteredCollection).isNotEmpty();
-        assertThat(((ProcessInstanceImpl)filteredCollection.iterator().next().getEntity()).getProcessDefinitionKey()).isEqualTo(PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY);
+        assertThat(((ProcessInstanceImpl)filteredCollection.iterator().next().getEntity()).getProcessDefinitionKey()).isEqualTo(processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"));
     }
 
     @Then("the user can query process with variables instances in admin endpoints")
     public void checkIfProcessWithVariablesArePresentQueryAdmin(){
-        assertThat(checkProcessInstances(querySteps.getAllProcessInstancesAdmin(),PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkProcessInstances(querySteps.getAllProcessInstancesAdmin(),processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isNotEmpty();
     }
 
     @Then("the user can get process with variables instances in admin endpoint")
     public void checkIfProcessWithVariablesArePresentAdmin(){
-        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstancesAdmin(), PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstancesAdmin(), processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isNotEmpty();
     }
 }

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/RuntimeLifecycleActions.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/RuntimeLifecycleActions.java
@@ -57,7 +57,7 @@ public class RuntimeLifecycleActions {
     }
 
     @AfterScenario
-    public void creanup() {
+    public void cleanup() {
         dirtyContextHandler.cleanup();
     }
 

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/Tasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/Tasks.java
@@ -16,8 +16,11 @@
 
 package org.activiti.cloud.qa.story;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
+import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
 import org.activiti.api.task.model.Task;
 import org.activiti.cloud.api.task.model.CloudTask;
@@ -107,5 +110,20 @@ public class Tasks {
         assertThat(subtasks).isNotNull().hasSize(1);
         assertThat(subtasks.iterator().hasNext()).isTrue();
         assertThat(subtasks.iterator().next()).extracting("id").containsOnly(subtask.getId());
+    }
+
+    @Then("the tasks has the formKey field")
+    public void checkIfFormKeyIsPresent(){
+        String processInstanceId = Serenity.sessionVariableCalled("processInstanceId").toString();
+        List<CloudTask> tasksFromRB = new ArrayList<>(
+                runtimeBundleSteps.getTaskByProcessInstanceId(processInstanceId));
+        assertThat(tasksFromRB).isNotEmpty();
+        newTask = tasksFromRB.get(0);
+        assertThat(newTask).isNotNull();
+        assertThat(newTask).extracting("formKey").contains("taskForm");
+
+        CloudTask taskFromQuery = querySteps.getTaskById(newTask.getId());
+        assertThat(taskFromQuery).isNotNull();
+        assertThat(taskFromQuery.getFormKey()).isEqualTo("taskForm");
     }
 }

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -6,7 +6,7 @@ I want to perform operations on process instances
 
 Scenario: delete a process instance
 Given the user is authenticated as testuser
-When the user starts a process with variables
+When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 And the user deletes the process
 Then the process instance is deleted
 
@@ -19,34 +19,34 @@ Then the process cannot be activated anymore
 
 Scenario: show a process instance diagram
 Given the user is authenticated as testuser
-When the user starts a process with variables
+When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 And open the process diagram
 Then the diagram is shown
 
 Scenario: show diagram for a process instance without graphic info
 Given the user is authenticated as testuser
-When the user starts a process without graphic info
+When the user starts a PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO
 And open the process diagram
 Then no diagram is shown
 
 Scenario: complete a process instance that uses a connector
 Given the user is authenticated as testuser
-When the user starts a connector process
+When the user starts a CONNECTOR_PROCESS_INSTANCE
 Then the status of the process is changed to completed
 And a variable was created with name var1
 
 Scenario: retrieve process instances as an admin
 Given the user is authenticated as hradmin
-When the user starts a process with variables
+When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 Then the user can get process with variables instances in admin endpoint
 
 Scenario: query process instances as an admin
 Given the user is authenticated as hradmin
-When the user starts a process with variables
+When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 Then the user can query process with variables instances in admin endpoints
 
 Scenario: get events as an admin
 Given the user is authenticated as hradmin
-When the user starts a process with variables
+When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 Then the user can get events for process with variables instances in admin endpoint
 

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -54,3 +54,7 @@ Given the user is authenticated as hradmin
 When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 Then the user can get events for process with variables instances in admin endpoint
 
+Scenario: check the presence of formKey field in task
+Given the user is authenticated as testuser
+Then the PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED definition has the formKey field with value startForm
+

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -4,12 +4,16 @@ Narrative:
 As a user
 I want to perform operations on process instances
 
+Scenario: check all process definitions are present
+Given the user is authenticated as testuser
+When the user gets the process definitions
+Then all the process definitions are present
+
 Scenario: delete a process instance
 Given the user is authenticated as testuser
 When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 And the user deletes the process
 Then the process instance is deleted
-
 
 Scenario: try activate a cancelled process instance
 Given the user is authenticated as testuser

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
@@ -7,7 +7,7 @@ So that I can get results on a running process
 
 Scenario: claim and complete tasks in a running process
 Given the user is authenticated as testuser
-When the user starts a process with variables
+When the user starts a PROCESS_INSTANCE_WITH_VARIABLES
 And the testuser claims the task
 And the user completes the task
 Then the status of the process and the task is changed to completed
@@ -37,14 +37,14 @@ Then a list of one subtask is be available for the task
 
 Scenario: create a process with assigned tasks and complete it
 Given the user is authenticated as testuser
-When the user starts a single-task process
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK
 And the status of the task since the beginning is ASSIGNED
 And the user completes the task
 Then the status of the process and the task is changed to completed
 
 Scenario: create a process with user candidates, claim a task and complete it
 Given the user is authenticated as testuser
-When the user starts a single-task process with user candidates
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES
 And the status of the task is CREATED
 And the testuser claims the task
 And the user completes the task
@@ -52,7 +52,7 @@ Then the status of the process and the task is changed to completed
 
 Scenario: create a process with group candidates, claim a task and complete it
 Given the user is authenticated as testuser
-When the user starts a single-task process with group candidates
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES
 And the status of the task is CREATED
 And the testuser claims the task
 And the user completes the task
@@ -60,19 +60,19 @@ Then the status of the process and the task is changed to completed
 
 Scenario: cannot complete a task that has already been completed
 Given the user is authenticated as testuser
-When the user starts a single-task process
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK
 And the user completes the task
 Then the user cannot complete the task
 
 Scenario: cannot claim a task that belongs to different candidate group
 Given the user is authenticated as testuser
-When the user starts a single-task process with group candidates for test group
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP
 And another user is authenticated as hruser
 Then the task cannot be claimed by hruser
 
 Scenario: cannot claim a task that has already been claimed
 Given the user is authenticated as testuser
-When the user starts a single-task process with user candidates
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_USER_CANDIDATES
 And the status of the task is CREATED
 And the testuser claims the task
 And the status of the task is ASSIGNED
@@ -81,13 +81,13 @@ Then the task cannot be claimed by hruser
 
 Scenario: cannot see tasks that belongs to different candidate group
 Given the user is authenticated as testuser
-When the user starts a single-task process with group candidates for test group
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP
 And the testuser claims the task
 And the status of the task is ASSIGNED
 And the user completes the task
 And the status of the task is COMPLETED
 And another user is authenticated as hruser
-Then tasks of SingleTaskProcessGroupCandidatesTestGroup cannot be seen by user
+Then tasks of PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP cannot be seen by user
 
 
 

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
@@ -37,7 +37,7 @@ Then a list of one subtask is be available for the task
 
 Scenario: create a process with assigned tasks and complete it
 Given the user is authenticated as testuser
-When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED
 And the status of the task since the beginning is ASSIGNED
 And the user completes the task
 Then the status of the process and the task is changed to completed
@@ -60,7 +60,7 @@ Then the status of the process and the task is changed to completed
 
 Scenario: cannot complete a task that has already been completed
 Given the user is authenticated as testuser
-When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED
 And the user completes the task
 Then the user cannot complete the task
 
@@ -89,6 +89,10 @@ And the status of the task is COMPLETED
 And another user is authenticated as hruser
 Then tasks of PROCESS_INSTANCE_WITH_SINGLE_TASK_AND_GROUP_CANDIDATES_FOR_TESTGROUP cannot be seen by user
 
+Scenario: subprocess task is created when starting a parent process with call activities
+Given the user is authenticated as testuser
+When the user starts a PROCESS_INSTANCE_WITH_CALL_ACTIVITIES
+Then the task from SUB_PROCESS_INSTANCE_WITH_TASK is CREATED and it is called subprocess-task
 
 
 

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
@@ -94,7 +94,10 @@ Given the user is authenticated as testuser
 When the user starts a PROCESS_INSTANCE_WITH_CALL_ACTIVITIES
 Then the task from SUB_PROCESS_INSTANCE_WITH_TASK is CREATED and it is called subprocess-task
 
-
+Scenario: check the presence of formKey field in task
+Given the user is authenticated as testuser
+When the user starts a PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED
+Then the tasks has the formKey field
 
 
 

--- a/security-policies-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/SecurityPoliciesActions.java
+++ b/security-policies-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/SecurityPoliciesActions.java
@@ -25,8 +25,7 @@ import org.jbehave.core.annotations.Then;
 
 import static org.activiti.cloud.qa.helper.Filters.checkEvents;
 import static org.activiti.cloud.qa.helper.Filters.checkProcessInstances;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY;
-import static org.activiti.cloud.qa.steps.RuntimeBundleSteps.SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY;
+import static org.activiti.cloud.qa.helper.ProcessMatcher.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -44,7 +43,7 @@ public class SecurityPoliciesActions {
     @Then("the user cannot start the process with variables")
     public void startProcess() throws Exception {
         try {
-            runtimeBundleSteps.startProcess(PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY);
+            runtimeBundleSteps.startProcess(processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"));
         }catch (FeignException exception){
             assertThat(exception.getMessage()).contains("Unable to find process definition for the given id:'ProcessWithVariables'");
         }
@@ -52,47 +51,47 @@ public class SecurityPoliciesActions {
 
     @Then("the user can get simple process instances")
     public void checkIfSimpleProcessInstancesArePresent(){
-        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstances(), SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstances(), processDefinitionKeys.get("SIMPLE_PROCESS_INSTANCE"))).isNotEmpty();
     }
 
     @Then("the user can get process with variables instances")
     public void checkIfProcessWithVariablesArePresent(){
-        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstances(), PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstances(), processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isNotEmpty();
     }
 
     @Then("the user can query simple process instances")
     public void checkIfSimpleProcessInstancesArePresentQuery(){
-        assertThat(checkProcessInstances(querySteps.getAllProcessInstances(), SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkProcessInstances(querySteps.getAllProcessInstances(), processDefinitionKeys.get("SIMPLE_PROCESS_INSTANCE"))).isNotEmpty();
     }
 
     @Then("the user can get events for simple process instances")
     public void checkIfEventsFromSimpleProcessesArePresent(){
-        assertThat(checkEvents(auditSteps.getAllEvents(),SIMPLE_PROCESS_INSTANCE_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkEvents(auditSteps.getAllEvents(),processDefinitionKeys.get("SIMPLE_PROCESS_INSTANCE"))).isNotEmpty();
     }
 
     @Then("the user can get events for process with variables instances")
     public void checkIfEventsFromProcessesWithVariablesArePresent(){
-        assertThat(checkEvents(auditSteps.getAllEvents(),PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkEvents(auditSteps.getAllEvents(),processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isNotEmpty();
     }
 
     @Then("the user cannot get events for process with variables instances")
     public void checkIfEventsFromProcessesWithVariablesAreNotPresent(){
-        assertThat(checkEvents(auditSteps.getAllEvents(),PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isEmpty();
+        assertThat(checkEvents(auditSteps.getAllEvents(),processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isEmpty();
     }
 
     @Then("the user cannot get process with variables instances")
     public void checkIfProcessWithVariablesAreNotPresent(){
-        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstances(), PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isEmpty();
+        assertThat(checkProcessInstances(runtimeBundleSteps.getAllProcessInstances(), processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isEmpty();
     }
 
     @Then("the user cannot query process with variables instances")
     public void checkIfProcessWithVariablesAreNotPresentQuery(){
-        assertThat(checkProcessInstances(querySteps.getAllProcessInstances(),PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isEmpty();
+        assertThat(checkProcessInstances(querySteps.getAllProcessInstances(),processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isEmpty();
     }
 
     @Then("the user can query process with variables instances")
     public void checkIfProcessWithVariablesArePresentQuery(){
-        assertThat(checkProcessInstances(querySteps.getAllProcessInstances(),PROCESS_INSTANCE_WITH_VARIABLES_DEFINITION_KEY)).isNotEmpty();
+        assertThat(checkProcessInstances(querySteps.getAllProcessInstances(),processDefinitionKeys.get("PROCESS_INSTANCE_WITH_VARIABLES"))).isNotEmpty();
     }
 
     @Then("the user can get tasks")

--- a/security-policies-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/SecurityPoliciesActions.java
+++ b/security-policies-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/SecurityPoliciesActions.java
@@ -25,7 +25,7 @@ import org.jbehave.core.annotations.Then;
 
 import static org.activiti.cloud.qa.helper.Filters.checkEvents;
 import static org.activiti.cloud.qa.helper.Filters.checkProcessInstances;
-import static org.activiti.cloud.qa.helper.ProcessMatcher.*;
+import static org.activiti.cloud.qa.helper.ProcessDefinitionRegistry.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 


### PR DESCRIPTION
This PR makes the addition of new process definitions scalable and seamless, centralizing the procedure and avoiding duplication.