### PR TITLE
Exclude groovy-all from serenity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
         <groupId>net.serenity-bdd</groupId>
         <artifactId>serenity-jbehave</artifactId>
         <version>${serenity-jbehave.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>groovy-all</artifactId>
+            <groupId>org.codehaus.groovy</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>net.serenity-bdd</groupId>


### PR DESCRIPTION
groovy-all jar is no longer available from version 2.5.0