### PR TITLE
Fix resume process

### DIFF
--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessRuntimeService.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessRuntimeService.java
@@ -22,9 +22,9 @@ public interface ProcessRuntimeService extends BaseService {
     @Headers("Content-Type: application/json")
     void suspendProcess(@Param("id") String id);
 
-    @RequestLine("POST /v1/process-instances/{id}/activate")
+    @RequestLine("POST /v1/process-instances/{id}/resume")
     @Headers("Content-Type: application/json")
-    void activateProcess(@Param("id") String id);
+    void resumeProcess(@Param("id") String id);
 
     @RequestLine("DELETE /v1/process-instances/{id}")
     @Headers("Content-Type: application/json")

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
@@ -108,8 +108,8 @@ public class ProcessRuntimeBundleSteps {
     }
 
     @Step
-    public void activateProcessInstance(String processInstanceId) {
-        processRuntimeService.activateProcess(processInstanceId);
+    public void resumeProcessInstance(String processInstanceId) {
+        processRuntimeService.resumeProcess(processInstanceId);
     }
 
     @Step


### PR DESCRIPTION
The url in the services was updated from "/activate" to "/resume"