### PR TITLE
Fix resume process

### DIFF
--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/ProcessAssertions.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/ProcessAssertions.java
@@ -2,9 +2,11 @@ package org.activiti.cloud.acc.core.assertions;
 
 import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
+import org.activiti.api.model.shared.event.VariableEvent;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
+import org.activiti.api.process.model.events.SequenceFlowTakenEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.jbehave.core.annotations.Then;
 import org.activiti.cloud.acc.core.steps.audit.AuditSteps;
@@ -74,7 +76,7 @@ public class ProcessAssertions {
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
-                            //SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
+                            SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED);
@@ -95,10 +97,10 @@ public class ProcessAssertions {
                     .containsExactlyInAnyOrder(
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_CREATED,
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED,
-                            //VariableEvent.VariableEvents.VARIABLE_CREATED,
+                            VariableEvent.VariableEvents.VARIABLE_CREATED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
-                            //SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
+                            SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED);
@@ -121,10 +123,10 @@ public class ProcessAssertions {
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
-                            //SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
+                            SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
-                            //SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
+                            SequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
                             BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                             ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED);

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessRuntimeService.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessRuntimeService.java
@@ -22,9 +22,9 @@ public interface ProcessRuntimeService extends BaseService {
     @Headers("Content-Type: application/json")
     void suspendProcess(@Param("id") String id);
 
-    @RequestLine("POST /v1/process-instances/{id}/activate")
+    @RequestLine("POST /v1/process-instances/{id}/resume")
     @Headers("Content-Type: application/json")
-    void activateProcess(@Param("id") String id);
+    void resumeProcess(@Param("id") String id);
 
     @RequestLine("DELETE /v1/process-instances/{id}")
     @Headers("Content-Type: application/json")

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
@@ -108,8 +108,8 @@ public class ProcessRuntimeBundleSteps {
     }
 
     @Step
-    public void activateProcessInstance(String processInstanceId) {
-        processRuntimeService.activateProcess(processInstanceId);
+    public void resumeProcessInstance(String processInstanceId) {
+        processRuntimeService.resumeProcess(processInstanceId);
     }
 
     @Step


### PR DESCRIPTION
Renamed method names in order to align the semantics of the api
Uncomment checks on events after fixes on how the fields they require