### PR TITLE
adjust tests with the new feign exception

### DIFF
--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.acc.core.assertions;
+
+import javax.servlet.http.HttpServletResponse;
+
+import feign.FeignException;
+import net.thucydides.core.steps.StepEventBus;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Rest errors assertions
+ */
+public class RestErrorAssert {
+
+    private FeignException exception;
+
+    private RestErrorAssert(FeignException exception) {
+        this.exception = exception;
+    }
+
+    public static RestErrorAssert assertThatFeignExceptionIsThrownBy(final ThrowingCallable throwingCallable) {
+        Throwable throwable = catchThrowable(throwingCallable);
+        assertThat(throwable).isInstanceOf(FeignException.class);
+
+        StepEventBus
+                .getEventBus()
+                .getBaseStepListener()
+                .exceptionExpected(FeignException.class);
+
+        return new RestErrorAssert((FeignException) throwable);
+    }
+
+    public static RestErrorAssert assertThatRestNotFoundErrorIsThrownBy(final ThrowingCallable throwingCallable) {
+        return assertThatFeignExceptionIsThrownBy(throwingCallable).withNotFoundCode();
+    }
+
+    public static RestErrorAssert assertThatRestBadRequestErrorIsThrownBy(final ThrowingCallable throwingCallable) {
+        return assertThatFeignExceptionIsThrownBy(throwingCallable).withBadRequestCode();
+    }
+
+    public static RestErrorAssert assertThatRestInternalServerErrorIsThrownBy(final ThrowingCallable throwingCallable) {
+        return assertThatFeignExceptionIsThrownBy(throwingCallable).withInternalServerErrorCode();
+    }
+
+    public RestErrorAssert withErrorCode(int expectedCode) {
+        assertThat(exception.status()).isEqualTo(expectedCode);
+        return this;
+    }
+
+    public RestErrorAssert withMessage(String expectedMessage) {
+        assertThat(exception.contentUTF8()).isEqualTo(expectedMessage);
+        return this;
+    }
+
+    public RestErrorAssert withMessageContaining(String expectedMessage) {
+        assertThat(exception.contentUTF8()).contains(expectedMessage);
+        return this;
+    }
+
+    public RestErrorAssert withBadRequestCode() {
+        return withErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    public RestErrorAssert withNotFoundCode() {
+        return withErrorCode(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    public RestErrorAssert withInternalServerErrorCode() {
+        return withErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
@@ -1,15 +1,10 @@
 package org.activiti.cloud.acc.core.steps.runtime;
 
-import static org.activiti.cloud.acc.core.helper.SvgToPng.svgToPng;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.FeignException;
 import net.thucydides.core.annotations.Step;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -23,6 +18,10 @@ import org.activiti.cloud.api.task.model.CloudTask;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.PagedResources;
+
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
+import static org.activiti.cloud.acc.core.helper.SvgToPng.svgToPng;
+import static org.assertj.core.api.Assertions.*;
 
 @EnableRuntimeFeignContext
 public class ProcessRuntimeBundleSteps {
@@ -91,9 +90,9 @@ public class ProcessRuntimeBundleSteps {
 
     @Step
     public void checkProcessInstanceNotFound(String processInstanceId) {
-        assertThatExceptionOfType(Exception.class).isThrownBy(
+        assertThatRestNotFoundErrorIsThrownBy(
                 () -> processRuntimeService.getProcessInstance(processInstanceId)
-        ).withMessageContaining("Unable to find process instance for the given id:");
+        ).withMessageContaining("Unable to find process instance for the given id:'" + processInstanceId + "'");
     }
 
     @Step
@@ -125,16 +124,6 @@ public class ProcessRuntimeBundleSteps {
     @Step
     public PagedResources<CloudProcessInstance> getAllProcessInstances(){
         return processRuntimeService.getAllProcessInstances();
-    }
-
-    @Step
-    public void checkProcessInstanceIsNotPresent(String id){
-        try{
-            processRuntimeService.getProcessInstance(id);
-
-        }catch (FeignException exception) {
-            assertThat(exception.getMessage()).contains("Unable to find process instance for the given id:'" + id + "'");
-        }
     }
 
     @Step
@@ -172,9 +161,9 @@ public class ProcessRuntimeBundleSteps {
     public void checkProcessInstanceName(String processInstanceId,
                                          String processInstanceName) {
         assertThat(processRuntimeService.getProcessInstance(processInstanceId).getName()).isEqualTo(processInstanceName);
-    }    
+    }
 
-  
+
     @Step
     public CloudProcessInstance setProcessName(String processInstanceId, String processInstanceName){
         return processRuntimeService.updateProcess(

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/TaskRuntimeBundleSteps.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/TaskRuntimeBundleSteps.java
@@ -1,7 +1,7 @@
 package org.activiti.cloud.acc.core.steps.runtime;
 
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.Date;
 import java.util.Map;
@@ -42,11 +42,9 @@ public class TaskRuntimeBundleSteps {
 
     @Step
     public void cannotClaimTask(String id){
-        assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> {
-                    taskRuntimeService
-                            .claimTask(id);
-                }).withMessageContaining("Unable to find task for the given id: " + id);
+        assertThatRestNotFoundErrorIsThrownBy(
+                () -> taskRuntimeService.claimTask(id)
+        ).withMessageContaining("Unable to find task for the given id: " + id);
     }
 
     @Step
@@ -58,12 +56,9 @@ public class TaskRuntimeBundleSteps {
 
     @Step
     public void cannotCompleteTask(String id, CompleteTaskPayload createTaskPayload) {
-        assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> {
-                            taskRuntimeService
-                                    .completeTask(id, createTaskPayload);
-                        }
-                ).withMessageContaining("Unable to find task for the given id: " + id);
+        assertThatRestNotFoundErrorIsThrownBy(
+                () -> taskRuntimeService.completeTask(id, createTaskPayload)
+        ).withMessageContaining("Unable to find task for the given id: " + id);
     }
 
     @Step
@@ -106,7 +101,7 @@ public class TaskRuntimeBundleSteps {
 
     @Step
     public void checkTaskNotFound(String taskId) {
-        assertThatExceptionOfType(Exception.class).isThrownBy(
+        assertThatRestNotFoundErrorIsThrownBy(
                 () -> taskRuntimeService.getTask(taskId)
         ).withMessageContaining("Unable to find task");
     }


### PR DESCRIPTION
- add RestErrorAssert for rest error assertions utils
- use FeignException.content() instead FeignException.getMessage() to assert the error message
- update steps to use assertThatRestNotFoundErrorIsThrownBy instead assertThatExceptionOfType