### PR TITLE
feat(ProcessQuerySteps): add query process diagram test steps

### DIFF
--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/rest/RuntimeFeignConfiguration.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/rest/RuntimeFeignConfiguration.java
@@ -27,10 +27,12 @@ import org.activiti.api.task.conf.impl.TaskModelAutoConfiguration;
 import org.activiti.cloud.acc.core.config.RuntimeTestsConfigurationProperties;
 import org.activiti.cloud.acc.core.services.audit.AuditService;
 import org.activiti.cloud.acc.core.services.audit.admin.AuditAdminService;
-import org.activiti.cloud.acc.core.services.query.ProcessQueryService;
 import org.activiti.cloud.acc.core.services.query.ProcessModelQueryService;
+import org.activiti.cloud.acc.core.services.query.ProcessQueryDiagramService;
+import org.activiti.cloud.acc.core.services.query.ProcessQueryService;
 import org.activiti.cloud.acc.core.services.query.TaskQueryService;
 import org.activiti.cloud.acc.core.services.query.admin.ProcessModelQueryAdminService;
+import org.activiti.cloud.acc.core.services.query.admin.ProcessQueryAdminDiagramService;
 import org.activiti.cloud.acc.core.services.query.admin.ProcessQueryAdminService;
 import org.activiti.cloud.acc.core.services.query.admin.TaskQueryAdminService;
 import org.activiti.cloud.acc.core.services.runtime.ProcessRuntimeService;
@@ -247,5 +249,30 @@ public class RuntimeFeignConfiguration {
                          new feign.codec.Decoder.Default())
                 .target(SwaggerService.class, runtimeTestsConfigurationProperties.getAuditEventUrl());
     }
+    
+    @Bean
+    public ProcessQueryDiagramService queryDiagramService() {
+        return Feign.builder()
+                .encoder(new GsonEncoder())
+                .errorDecoder(new FeignErrorDecoder())
+                .logger(new Logger.ErrorLogger())
+                .logLevel(Logger.Level.FULL)
+                .requestInterceptor(new OAuth2FeignRequestInterceptor())
+                .target(ProcessQueryDiagramService.class,
+                        runtimeTestsConfigurationProperties.getQueryUrl());
+    }    
+    
+    @Bean
+    public ProcessQueryAdminDiagramService queryAdminDiagramService() {
+        return Feign.builder()
+                .encoder(new GsonEncoder())
+                .errorDecoder(new FeignErrorDecoder())
+                .logger(new Logger.ErrorLogger())
+                .logLevel(Logger.Level.FULL)
+                .requestInterceptor(new OAuth2FeignRequestInterceptor())
+                .target(ProcessQueryAdminDiagramService.class,
+                        runtimeTestsConfigurationProperties.getQueryUrl());
+    }    
+    
 
 }

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/query/ProcessQueryDiagramService.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/query/ProcessQueryDiagramService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.acc.core.services.query;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+
+/**
+ * Runtime Bundle service to manage diagrams
+ */
+public interface ProcessQueryDiagramService {
+
+    @RequestLine("GET /v1/process-instances/{id}/diagram")
+    @Headers({
+            "Content-Type: image/svg+xml"
+    })
+    String getProcessInstanceDiagram(@Param("id") String id);
+
+}

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/query/admin/ProcessQueryAdminDiagramService.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/query/admin/ProcessQueryAdminDiagramService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.acc.core.services.query.admin;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+
+/**
+ * Runtime Bundle service to manage diagrams
+ */
+public interface ProcessQueryAdminDiagramService {
+
+    @RequestLine("GET /admin/v1/process-instances/{id}/diagram")
+    @Headers({
+            "Content-Type: image/svg+xml"
+    })
+    String getProcessInstanceDiagram(@Param("id") String id);
+
+}

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
@@ -1,5 +1,6 @@
 package org.activiti.cloud.acc.core.steps.query;
 
+import static org.activiti.cloud.acc.core.helper.SvgToPng.svgToPng;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -12,6 +13,7 @@ import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.cloud.acc.core.rest.feign.EnableRuntimeFeignContext;
 import org.activiti.cloud.acc.core.services.query.ProcessModelQueryService;
+import org.activiti.cloud.acc.core.services.query.ProcessQueryDiagramService;
 import org.activiti.cloud.acc.core.services.query.ProcessQueryService;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -27,6 +29,9 @@ public class ProcessQuerySteps {
     @Autowired
     private ProcessModelQueryService processModelQueryService;
 
+    @Autowired
+    private ProcessQueryDiagramService processQueryDiagramService;
+    
     @Step
     public void checkServicesHealth() {
         assertThat(processQueryService.isServiceUp()).isTrue();
@@ -112,5 +117,21 @@ public class ProcessQuerySteps {
     public PagedResources<CloudProcessInstance> getProcessInstancesByProcessDefinitionKey(String processDefinitionKey){
         return processQueryService.getProcessInstancesByProcessDefinitionKey(processDefinitionKey);
     }
+    
+    @Step
+    public String getProcessInstanceDiagram(String id) {
+        return processQueryDiagramService.getProcessInstanceDiagram(id);
+    }
+
+    @Step
+    public void checkProcessInstanceDiagram(String diagram) throws Exception {
+        assertThat(diagram).isNotEmpty();
+        assertThat(svgToPng(diagram.getBytes())).isNotEmpty();
+    }
+
+    @Step
+    public void checkProcessInstanceNoDiagram(String diagram) {
+        assertThat(diagram).isEmpty();
+    }    
 
 }

--- a/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/admin/ProcessQueryAdminSteps.java
+++ b/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/admin/ProcessQueryAdminSteps.java
@@ -1,8 +1,12 @@
 package org.activiti.cloud.acc.core.steps.query.admin;
 
+import static org.activiti.cloud.acc.core.helper.SvgToPng.svgToPng;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import net.thucydides.core.annotations.Step;
 import org.activiti.cloud.acc.core.rest.feign.EnableRuntimeFeignContext;
 import org.activiti.cloud.acc.core.services.query.admin.ProcessModelQueryAdminService;
+import org.activiti.cloud.acc.core.services.query.admin.ProcessQueryAdminDiagramService;
 import org.activiti.cloud.acc.core.services.query.admin.ProcessQueryAdminService;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -10,8 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableRuntimeFeignContext
 public class ProcessQueryAdminSteps {
@@ -22,6 +24,9 @@ public class ProcessQueryAdminSteps {
     @Autowired
     private ProcessModelQueryAdminService processModelQueryAdminService;
 
+    @Autowired
+    private ProcessQueryAdminDiagramService processQueryAdminDiagramService;
+    
     @Step
     public void checkServicesHealth() {
         assertThat(processQueryAdminService.isServiceUp()).isTrue();
@@ -51,5 +56,17 @@ public class ProcessQueryAdminSteps {
     public Resources<Resource<CloudProcessInstance>> deleteProcessInstances(){
         return processQueryAdminService.deleteProcessInstances();
     }
-
+    @Step
+    public String getProcessInstanceDiagram(String id) {
+        return processQueryAdminDiagramService.getProcessInstanceDiagram(id);
+    }
+    @Step
+    public void checkProcessInstanceDiagram(String diagram) throws Exception {
+        assertThat(diagram).isNotEmpty();
+        assertThat(svgToPng(diagram.getBytes())).isNotEmpty();
+    }
+    @Step
+    public void checkProcessInstanceNoDiagram(String diagram) {
+        assertThat(diagram).isEmpty();
+    }
 }


### PR DESCRIPTION
This PR adds process query diagram service steps for user and admin endpoints

Part of https://github.com/Activiti/Activiti/issues/2750

Depends on https://github.com/Activiti/activiti-cloud-query-service/pull/238