### PR TITLE
fix: Extracted external dependencies to root pom dependency management

### DIFF
--- a/activiti-cloud-acceptance-tests-dependencies/pom.xml
+++ b/activiti-cloud-acceptance-tests-dependencies/pom.xml
@@ -13,13 +13,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.cloud.api</groupId>
-        <artifactId>activiti-cloud-api-dependencies</artifactId>
-        <version>${activiti-cloud-api.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.acc</groupId>
         <artifactId>activiti-cloud-acceptance-tests-shared</artifactId>
         <version>${activiti-cloud-acceptance-tests.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <module>activiti-cloud-acceptance-tests-core</module>
   </modules>
   <properties>
+    <activiti-cloud-build.version>7.1.30</activiti-cloud-build.version>
     <activiti-cloud-api.version>7.1.118</activiti-cloud-api.version>
     <activiti-cloud-acceptance-tests.version>${project.version}</activiti-cloud-acceptance-tests.version>
     <serenity.version>1.9.6</serenity.version>
@@ -30,6 +31,20 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.activiti.cloud.build</groupId>
+        <artifactId>activiti-cloud-dependencies-parent</artifactId>
+        <version>${activiti-cloud-build.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud.api</groupId>
+        <artifactId>activiti-cloud-api-dependencies</artifactId>
+        <version>${activiti-cloud-api.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>net.serenity-bdd</groupId>
         <artifactId>serenity-core</artifactId>


### PR DESCRIPTION
This PR fixes activiti-cloud-runtime-bundle-dependencies management BoM to extract external dependencies BoMs into root pom dependency management section

Part of https://github.com/Activiti/Activiti/issues/3099